### PR TITLE
Allow compatability with old wlan style interfaces

### DIFF
--- a/create_ap/config.py
+++ b/create_ap/config.py
@@ -68,10 +68,16 @@ class ConfigWriter(Config):
         log.debug("Obtaining wireless interface")
         iface_out = None
         name_regex = self.get_interface_regex("wlan")
+        fallback_name_regex = re.compile('w[a-z]{1,3}[0-9]')
         try:
             iface_out = self.get_proc_wifi_interface(name_regex)
         except RuntimeError:
             iface_out = self.get_sys_wifi_interface(name_regex)
+        if iface_out == None:
+            try:
+                iface_out = self.get_proc_wifi_interface(fallback_name_regex)
+            except RuntimeError:
+                iface_out = self.get_sys_wifi_interface(fallback_name_regex)
         if iface_out == None:
             raise RuntimeError("Unable to identify wireless interface.")
         else:

--- a/create_ap/config.py
+++ b/create_ap/config.py
@@ -79,9 +79,11 @@ class ConfigWriter(Config):
 
 
     def get_wireless_interface(self):
+        """ Gets the name of the wireless interface."""
         log.debug("Obtaining wireless interface")
         iface_out = None
         new_name_regex = self.get_interface_regex("wlan")
+        # Kali only runs bleeding edge so iface naming is in flux
         fallback_name_regex = re.compile('w[a-z]{1,3}[0-9]')
         name_regexes = [fallback_name_regex, new_name_regex]
         for name_regex in name_regexes:


### PR DESCRIPTION
This change puts back in the old interface naming style since the bleeding edge Kali distribution for embedded devices continues to change the iface naming stack.  